### PR TITLE
Added common.yml playbook and updated inventory

### DIFF
--- a/playbooks/common.yml
+++ b/playbooks/common.yml
@@ -1,0 +1,58 @@
+---
+- name: update web, nfs, and db servers
+  hosts: webservers, nfs, db
+  become: yes
+  tasks:
+    - name: ensure wireshark is at the latest version
+      yum:
+        name: wireshark
+        state: latest
+
+    - name: create a directory and a file inside it
+      file:
+        path: /tmp/test_directory
+        state: directory
+        mode: '0755'
+
+    - name: create a file in the directory
+      copy:
+        content: "This is a test file created by Ansible."
+        dest: /tmp/test_directory/test_file.txt
+
+    - name: set timezone to UTC
+      command: timedatectl set-timezone UTC
+
+    - name: run a shell script
+      shell: |
+        echo "Shell script executed on $(date)" >> /tmp/shell_script.log
+
+- name: update LB server
+  hosts: lb
+  become: yes
+  tasks:
+    - name: Update apt repo
+      apt: 
+        update_cache: yes
+
+    - name: ensure wireshark is at the latest version
+      apt:
+        name: wireshark
+        state: latest
+
+    - name: create a directory and a file inside it
+      file:
+        path: /tmp/test_directory
+        state: directory
+        mode: '0755'
+
+    - name: create a file in the directory
+      copy:
+        content: "This is a test file created by Ansible."
+        dest: /tmp/test_directory/test_file.txt
+
+    - name: set timezone to UTC
+      command: timedatectl set-timezone UTC
+
+    - name: run a shell script
+      shell: |
+        echo "Shell script executed on $(date)" >> /tmp/shell_script.log


### PR DESCRIPTION
This PR adds the `common.yml` playbook which includes configuration for updating and installing packages on webservers, NFS, and DB servers, as well as load balancers. 

Inventory file was updated with IP addresses for NFS, web servers, DB, and load balancer.

Changes are intended to automate configuration tasks across the infrastructure.
